### PR TITLE
Fix where the pre_commit package should be pulled from

### DIFF
--- a/chat_gpt.yml
+++ b/chat_gpt.yml
@@ -1,4 +1,4 @@
 name: chat_gpt
 dependencies:
-  - pre_commit==3.7.1
+  - conda-forge::pre_commit==3.7.1
   - python==3.12.3


### PR DESCRIPTION
We need to go to conda-forge for the latest version