### PR TITLE
Add Move and Square classes, generated initially by ChatGPT

### DIFF
--- a/chess_engine_v1/move.py
+++ b/chess_engine_v1/move.py
@@ -3,13 +3,6 @@ from square import Square
 BOARD_SIZE = 8
 
 
-def square_to_alg(square):
-    files = "abcdefgh"
-    ranks = "12345678"
-    # TODO: Chris: Figure out the logic of how ranks is converted.
-    return files[square[1]] + ranks[(BOARD_SIZE - 1) - square[0]]
-
-
 class Move:
     def __init__(
         self,

--- a/chess_engine_v1/move.py
+++ b/chess_engine_v1/move.py
@@ -1,23 +1,40 @@
+from square import Square
+
+BOARD_SIZE = 8
+
+
+def square_to_alg(square):
+    files = "abcdefgh"
+    ranks = "12345678"
+    # TODO: Chris: Figure out the logic of how ranks is converted.
+    return files[square[1]] + ranks[(BOARD_SIZE - 1) - square[0]]
+
+
 class Move:
     def __init__(
         self,
-        start: tuple[int, int],
-        end: tuple[int, int],
+        start: Square,
+        end: Square,
         piece_moved: str,
-        piece_captured: str = " ",
+        piece_captured: str | None = None,
         promotion_piece: str | None = None,
     ):
-        self.start: tuple[int, int] = start
-        self.end: tuple[int, int] = end
-        self.piece_moved: str = piece_moved
-        self.piece_captured: str = piece_captured
-        self.promotion_piece: str | None = promotion_piece
+        self.start = start
+        self.end = end
+        self.piece_moved = piece_moved
+        self.piece_captured = piece_captured
+        self.promotion_piece = promotion_piece
 
     def __str__(self) -> str:
+        val = f"{self.piece_moved} from {self.start} to {self.end}"
+
+        if self.piece_captured:
+            val += f", capturing {self.piece_captured}"
+
         if self.promotion_piece:
-            return f"{self.piece_moved} from {self.start} to {self.end}, capturing {self.piece_captured}, promoting to {self.promotion_piece}"  # noqa
-        else:
-            return f"{self.piece_moved} from {self.start} to {self.end}, capturing {self.piece_captured}"  # noqa
+            val += f", promoting to {self.promotion_piece}"
+
+        return val
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/chess_engine_v1/move.py
+++ b/chess_engine_v1/move.py
@@ -1,0 +1,45 @@
+class Move:
+    def __init__(
+        self,
+        start: tuple[int, int],
+        end: tuple[int, int],
+        piece_moved: str,
+        piece_captured: str = " ",
+        promotion_piece: str | None = None,
+    ):
+        self.start: tuple[int, int] = start
+        self.end: tuple[int, int] = end
+        self.piece_moved: str = piece_moved
+        self.piece_captured: str = piece_captured
+        self.promotion_piece: str | None = promotion_piece
+
+    def __str__(self) -> str:
+        if self.promotion_piece:
+            return f"{self.piece_moved} from {self.start} to {self.end}, capturing {self.piece_captured}, promoting to {self.promotion_piece}"  # noqa
+        else:
+            return f"{self.piece_moved} from {self.start} to {self.end}, capturing {self.piece_captured}"  # noqa
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Move):
+            return NotImplemented
+        return (
+            self.start == other.start
+            and self.end == other.end
+            and self.piece_moved == other.piece_moved
+            and self.piece_captured == other.piece_captured
+            and self.promotion_piece == other.promotion_piece
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.start,
+                self.end,
+                self.piece_moved,
+                self.piece_captured,
+                self.promotion_piece,
+            )
+        )

--- a/chess_engine_v1/move_test.py
+++ b/chess_engine_v1/move_test.py
@@ -1,0 +1,72 @@
+import unittest
+
+from move import Move
+
+
+class TestMove(unittest.TestCase):
+    def test_move_initialization(self):
+        move = Move((1, 0), (3, 0), "P", "p")
+        self.assertEqual(move.start, (1, 0))
+        self.assertEqual(move.end, (3, 0))
+        self.assertEqual(move.piece_moved, "P")
+        self.assertEqual(move.piece_captured, "p")
+        self.assertIsNone(move.promotion_piece)
+
+    def test_move_initialization_with_promotion(self):
+        move = Move((6, 0), (7, 0), "P", " ", "Q")
+        self.assertEqual(move.start, (6, 0))
+        self.assertEqual(move.end, (7, 0))
+        self.assertEqual(move.piece_moved, "P")
+        self.assertEqual(move.piece_captured, " ")
+        self.assertEqual(move.promotion_piece, "Q")
+
+    def test_move_str(self):
+        move = Move((1, 0), (3, 0), "P", "p")
+        self.assertEqual(str(move), "P from (1, 0) to (3, 0), capturing p")
+
+    def test_move_str_with_promotion(self):
+        move = Move((6, 0), (7, 0), "P", " ", "Q")
+        self.assertEqual(
+            str(move), "P from (6, 0) to (7, 0), capturing  , promoting to Q"
+        )
+
+    def test_move_repr(self):
+        move = Move((1, 0), (3, 0), "P", "p")
+        self.assertEqual(repr(move), "P from (1, 0) to (3, 0), capturing p")
+
+    def test_move_repr_with_promotion(self):
+        move = Move((6, 0), (7, 0), "P", " ", "Q")
+        self.assertEqual(
+            repr(move), "P from (6, 0) to (7, 0), capturing  , promoting to Q"
+        )
+
+    def test_move_equality(self):
+        move1 = Move((1, 0), (3, 0), "P", "p")
+        move2 = Move((1, 0), (3, 0), "P", "p")
+        self.assertEqual(move1, move2)
+
+    def test_move_inequality(self):
+        move1 = Move((1, 0), (3, 0), "P", "p")
+        move2 = Move((1, 0), (2, 0), "P", "p")
+        self.assertNotEqual(move1, move2)
+
+    def test_move_inequality_with_promotion(self):
+        move1 = Move((6, 0), (7, 0), "P", " ", "Q")
+        move2 = Move((6, 0), (7, 0), "P", " ", "R")
+        self.assertNotEqual(move1, move2)
+
+    def test_move_hash(self):
+        move1 = Move((1, 0), (3, 0), "P", "p")
+        move2 = Move((1, 0), (3, 0), "P", "p")
+        move_set = {move1, move2}
+        self.assertEqual(len(move_set), 1)
+
+    def test_move_hash_with_promotion(self):
+        move1 = Move((6, 0), (7, 0), "P", " ", "Q")
+        move2 = Move((6, 0), (7, 0), "P", " ", "Q")
+        move_set = {move1, move2}
+        self.assertEqual(len(move_set), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/chess_engine_v1/move_test.py
+++ b/chess_engine_v1/move_test.py
@@ -1,69 +1,98 @@
 import unittest
 
 from move import Move
+from square import Square
 
 
 class TestMove(unittest.TestCase):
     def test_move_initialization(self):
-        move = Move((1, 0), (3, 0), "P", "p")
-        self.assertEqual(move.start, (1, 0))
-        self.assertEqual(move.end, (3, 0))
+        start = Square("e2")
+        end = Square("e4")
+        move = Move(start, end, "P", "p")
+        self.assertEqual(move.start, start)
+        self.assertEqual(move.end, end)
         self.assertEqual(move.piece_moved, "P")
         self.assertEqual(move.piece_captured, "p")
         self.assertIsNone(move.promotion_piece)
 
     def test_move_initialization_with_promotion(self):
-        move = Move((6, 0), (7, 0), "P", " ", "Q")
-        self.assertEqual(move.start, (6, 0))
-        self.assertEqual(move.end, (7, 0))
+        start = Square("e7")
+        end = Square("e8")
+        move = Move(start, end, "P", " ", "Q")
+        self.assertEqual(move.start, start)
+        self.assertEqual(move.end, end)
         self.assertEqual(move.piece_moved, "P")
         self.assertEqual(move.piece_captured, " ")
         self.assertEqual(move.promotion_piece, "Q")
 
     def test_move_str(self):
-        move = Move((1, 0), (3, 0), "P", "p")
-        self.assertEqual(str(move), "P from (1, 0) to (3, 0), capturing p")
+        start = Square("e2")
+        end = Square("e4")
+        move = Move(start, end, "P", "p")
+        self.assertEqual(str(move), "P from e2 to e4, capturing p")
 
     def test_move_str_with_promotion(self):
-        move = Move((6, 0), (7, 0), "P", " ", "Q")
-        self.assertEqual(
-            str(move), "P from (6, 0) to (7, 0), capturing  , promoting to Q"
-        )
+        start = Square("e7")
+        end = Square("e8")
+        move = Move(start, end, "P", " ", "Q")
+        self.assertEqual(str(move), "P from e7 to e8, capturing  , promoting to Q")
 
     def test_move_repr(self):
-        move = Move((1, 0), (3, 0), "P", "p")
-        self.assertEqual(repr(move), "P from (1, 0) to (3, 0), capturing p")
+        start = Square("e2")
+        end = Square("e4")
+        move = Move(start, end, "P", "p")
+        self.assertEqual(repr(move), "P from e2 to e4, capturing p")
 
     def test_move_repr_with_promotion(self):
-        move = Move((6, 0), (7, 0), "P", " ", "Q")
-        self.assertEqual(
-            repr(move), "P from (6, 0) to (7, 0), capturing  , promoting to Q"
-        )
+        start = Square("e7")
+        end = Square("e8")
+        move = Move(start, end, "P", " ", "Q")
+        self.assertEqual(repr(move), "P from e7 to e8, capturing  , promoting to Q")
 
     def test_move_equality(self):
-        move1 = Move((1, 0), (3, 0), "P", "p")
-        move2 = Move((1, 0), (3, 0), "P", "p")
+        start1 = Square("e2")
+        end1 = Square("e4")
+        move1 = Move(start1, end1, "P", "p")
+        start2 = Square("e2")
+        end2 = Square("e4")
+        move2 = Move(start2, end2, "P", "p")
         self.assertEqual(move1, move2)
 
     def test_move_inequality(self):
-        move1 = Move((1, 0), (3, 0), "P", "p")
-        move2 = Move((1, 0), (2, 0), "P", "p")
+        start1 = Square("e2")
+        end1 = Square("e4")
+        move1 = Move(start1, end1, "P", "p")
+        start2 = Square("d2")
+        end2 = Square("d4")
+        move2 = Move(start2, end2, "P", "p")
         self.assertNotEqual(move1, move2)
 
     def test_move_inequality_with_promotion(self):
-        move1 = Move((6, 0), (7, 0), "P", " ", "Q")
-        move2 = Move((6, 0), (7, 0), "P", " ", "R")
+        start1 = Square("e7")
+        end1 = Square("e8")
+        move1 = Move(start1, end1, "P", " ", "Q")
+        start2 = Square("e7")
+        end2 = Square("e8")
+        move2 = Move(start2, end2, "P", " ", "R")
         self.assertNotEqual(move1, move2)
 
     def test_move_hash(self):
-        move1 = Move((1, 0), (3, 0), "P", "p")
-        move2 = Move((1, 0), (3, 0), "P", "p")
+        start1 = Square("e2")
+        end1 = Square("e4")
+        move1 = Move(start1, end1, "P", "p")
+        start2 = Square("e2")
+        end2 = Square("e4")
+        move2 = Move(start2, end2, "P", "p")
         move_set = {move1, move2}
         self.assertEqual(len(move_set), 1)
 
     def test_move_hash_with_promotion(self):
-        move1 = Move((6, 0), (7, 0), "P", " ", "Q")
-        move2 = Move((6, 0), (7, 0), "P", " ", "Q")
+        start1 = Square("e7")
+        end1 = Square("e8")
+        move1 = Move(start1, end1, "P", " ", "Q")
+        start2 = Square("e7")
+        end2 = Square("e8")
+        move2 = Move(start2, end2, "P", " ", "Q")
         move_set = {move1, move2}
         self.assertEqual(len(move_set), 1)
 

--- a/chess_engine_v1/move_test.py
+++ b/chess_engine_v1/move_test.py
@@ -1,98 +1,71 @@
 import unittest
 
 from move import Move
-from square import Square
+from square import Squares
 
 
 class TestMove(unittest.TestCase):
     def test_move_initialization(self):
-        start = Square("e2")
-        end = Square("e4")
-        move = Move(start, end, "P", "p")
-        self.assertEqual(move.start, start)
-        self.assertEqual(move.end, end)
+        move = Move(Squares.E2, Squares.E4, "P", "p")
+        self.assertEqual(move.start, Squares.E2)
+        self.assertEqual(move.end, Squares.E4)
         self.assertEqual(move.piece_moved, "P")
         self.assertEqual(move.piece_captured, "p")
         self.assertIsNone(move.promotion_piece)
 
     def test_move_initialization_with_promotion(self):
-        start = Square("e7")
-        end = Square("e8")
-        move = Move(start, end, "P", " ", "Q")
-        self.assertEqual(move.start, start)
-        self.assertEqual(move.end, end)
+        move = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
+        self.assertEqual(move.start, Squares.E7)
+        self.assertEqual(move.end, Squares.E8)
         self.assertEqual(move.piece_moved, "P")
-        self.assertEqual(move.piece_captured, " ")
+        self.assertEqual(move.piece_captured, None)
         self.assertEqual(move.promotion_piece, "Q")
 
     def test_move_str(self):
-        start = Square("e2")
-        end = Square("e4")
-        move = Move(start, end, "P", "p")
+        move = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(str(move), "P from e2 to e4, capturing p")
 
     def test_move_str_with_promotion(self):
-        start = Square("e7")
-        end = Square("e8")
-        move = Move(start, end, "P", " ", "Q")
-        self.assertEqual(str(move), "P from e7 to e8, capturing  , promoting to Q")
+        move = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
+        self.assertEqual(str(move), "P from e7 to e8, promoting to Q")
 
     def test_move_repr(self):
-        start = Square("e2")
-        end = Square("e4")
-        move = Move(start, end, "P", "p")
+        move = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(repr(move), "P from e2 to e4, capturing p")
 
     def test_move_repr_with_promotion(self):
-        start = Square("e7")
-        end = Square("e8")
-        move = Move(start, end, "P", " ", "Q")
-        self.assertEqual(repr(move), "P from e7 to e8, capturing  , promoting to Q")
+        move = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
+        self.assertEqual(repr(move), "P from e7 to e8, promoting to Q")
 
     def test_move_equality(self):
-        start1 = Square("e2")
-        end1 = Square("e4")
-        move1 = Move(start1, end1, "P", "p")
-        start2 = Square("e2")
-        end2 = Square("e4")
-        move2 = Move(start2, end2, "P", "p")
+        move1 = Move(Squares.E2, Squares.E4, "P", "p")
+        move2 = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(move1, move2)
 
     def test_move_inequality(self):
-        start1 = Square("e2")
-        end1 = Square("e4")
-        move1 = Move(start1, end1, "P", "p")
-        start2 = Square("d2")
-        end2 = Square("d4")
-        move2 = Move(start2, end2, "P", "p")
+        move1 = Move(Squares.E2, Squares.E4, "P", "p")
+        move2 = Move(Squares.D2, Squares.D4, "P", "p")
+        self.assertNotEqual(move1, move2)
+
+    def test_move_inequality_same_piece_and_squares_other_player(self):
+        move1 = Move(Squares.E2, Squares.E4, "R")
+        move2 = Move(Squares.E2, Squares.E4, "r")
         self.assertNotEqual(move1, move2)
 
     def test_move_inequality_with_promotion(self):
-        start1 = Square("e7")
-        end1 = Square("e8")
-        move1 = Move(start1, end1, "P", " ", "Q")
-        start2 = Square("e7")
-        end2 = Square("e8")
-        move2 = Move(start2, end2, "P", " ", "R")
+        move1 = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
+        move2 = Move(Squares.E7, Squares.E8, "P", promotion_piece="R")
         self.assertNotEqual(move1, move2)
 
     def test_move_hash(self):
-        start1 = Square("e2")
-        end1 = Square("e4")
-        move1 = Move(start1, end1, "P", "p")
-        start2 = Square("e2")
-        end2 = Square("e4")
-        move2 = Move(start2, end2, "P", "p")
+        move1 = Move(Squares.E2, Squares.E4, "P", "p")
+        move2 = Move(Squares.E2, Squares.E4, "P", "p")
         move_set = {move1, move2}
         self.assertEqual(len(move_set), 1)
 
     def test_move_hash_with_promotion(self):
-        start1 = Square("e7")
-        end1 = Square("e8")
-        move1 = Move(start1, end1, "P", " ", "Q")
-        start2 = Square("e7")
-        end2 = Square("e8")
-        move2 = Move(start2, end2, "P", " ", "Q")
+        move1 = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
+        move2 = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         move_set = {move1, move2}
         self.assertEqual(len(move_set), 1)
 

--- a/chess_engine_v1/square.py
+++ b/chess_engine_v1/square.py
@@ -1,0 +1,161 @@
+class Square:
+    def __init__(self, algebraic: str):
+        self.algebraic = algebraic
+        self.row = int(algebraic[1]) - 1
+        self.col = ord(algebraic[0]) - ord("a")
+
+    # @classmethod
+    # def square_from_row_col(cls, row: int, col: int) -> "Square":
+
+    def __str__(self) -> str:
+        return self.algebraic
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Square):
+            return NotImplemented
+        return self.algebraic == other.algebraic
+
+    def __hash__(self) -> int:
+        return hash(self.algebraic)
+
+
+class Squares:
+    A1 = Square("a1")
+    A2 = Square("a2")
+    A3 = Square("a3")
+    A4 = Square("a4")
+    A5 = Square("a5")
+    A6 = Square("a6")
+    A7 = Square("a7")
+    A8 = Square("a8")
+    B1 = Square("b1")
+    B2 = Square("b2")
+    B3 = Square("b3")
+    B4 = Square("b4")
+    B5 = Square("b5")
+    B6 = Square("b6")
+    B7 = Square("b7")
+    B8 = Square("b8")
+    C1 = Square("c1")
+    C2 = Square("c2")
+    C3 = Square("c3")
+    C4 = Square("c4")
+    C5 = Square("c5")
+    C6 = Square("c6")
+    C7 = Square("c7")
+    C8 = Square("c8")
+    D1 = Square("d1")
+    D2 = Square("d2")
+    D3 = Square("d3")
+    D4 = Square("d4")
+    D5 = Square("d5")
+    D6 = Square("d6")
+    D7 = Square("d7")
+    D8 = Square("d8")
+    E1 = Square("e1")
+    E2 = Square("e2")
+    E3 = Square("e3")
+    E4 = Square("e4")
+    E5 = Square("e5")
+    E6 = Square("e6")
+    E7 = Square("e7")
+    E8 = Square("e8")
+    F1 = Square("f1")
+    F2 = Square("f2")
+    F3 = Square("f3")
+    F4 = Square("f4")
+    F5 = Square("f5")
+    F6 = Square("f6")
+    F7 = Square("f7")
+    F8 = Square("f8")
+    G1 = Square("g1")
+    G2 = Square("g2")
+    G3 = Square("g3")
+    G4 = Square("g4")
+    G5 = Square("g5")
+    G6 = Square("g6")
+    G7 = Square("g7")
+    G8 = Square("g8")
+    H1 = Square("h1")
+    H2 = Square("h2")
+    H3 = Square("h3")
+    H4 = Square("h4")
+    H5 = Square("h5")
+    H6 = Square("h6")
+    H7 = Square("h7")
+    H8 = Square("h8")
+
+    square_in_order = (
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
+        A6,
+        A7,
+        A8,
+        B1,
+        B2,
+        B3,
+        B4,
+        B5,
+        B6,
+        B7,
+        B8,
+        C1,
+        C2,
+        C3,
+        C4,
+        C5,
+        C6,
+        C7,
+        C8,
+        D1,
+        D2,
+        D3,
+        D4,
+        D5,
+        D6,
+        D7,
+        D8,
+        E1,
+        E2,
+        E3,
+        E4,
+        E5,
+        E6,
+        E7,
+        E8,
+        F1,
+        F2,
+        F3,
+        F4,
+        F5,
+        F6,
+        F7,
+        F8,
+        G1,
+        G2,
+        G3,
+        G4,
+        G5,
+        G6,
+        G7,
+        G8,
+        H1,
+        H2,
+        H3,
+        H4,
+        H5,
+        H6,
+        H7,
+        H8,
+    )
+
+    @classmethod
+    def square_from_row_col(cls, row: int, col: int) -> Square:
+        index = col * 8 + row
+        return cls.square_in_order[index]

--- a/chess_engine_v1/square_test.py
+++ b/chess_engine_v1/square_test.py
@@ -1,0 +1,66 @@
+import unittest
+
+from square import Square, Squares
+
+
+class TestSquare(unittest.TestCase):
+    def test_square_initialization(self):
+        square = Square("e4")
+        self.assertEqual(square.algebraic, "e4")
+        self.assertEqual(square.row, 3)
+        self.assertEqual(square.col, 4)
+
+    def test_square_row(self):
+        self.assertEqual(Squares.A1.row, 0)
+        self.assertEqual(Squares.B8.row, 7)
+        self.assertEqual(Squares.C2.row, 1)
+        self.assertEqual(Squares.D7.row, 6)
+        self.assertEqual(Squares.E3.row, 2)
+        self.assertEqual(Squares.F6.row, 5)
+        self.assertEqual(Squares.G4.row, 3)
+        self.assertEqual(Squares.H5.row, 4)
+
+    def test_square_col(self):
+        self.assertEqual(Squares.A1.col, 0)
+        self.assertEqual(Squares.B8.col, 1)
+        self.assertEqual(Squares.C2.col, 2)
+        self.assertEqual(Squares.D7.col, 3)
+        self.assertEqual(Squares.E3.col, 4)
+        self.assertEqual(Squares.F6.col, 5)
+        self.assertEqual(Squares.G4.col, 6)
+        self.assertEqual(Squares.H5.col, 7)
+
+    def test_square_str(self):
+        square = Square("e4")
+        self.assertEqual(str(square), "e4")
+
+    def test_square_repr(self):
+        square = Square("e4")
+        self.assertEqual(repr(square), "e4")
+
+    def test_square_equality(self):
+        square1 = Square("e4")
+        square2 = Square("e4")
+        self.assertEqual(square1, square2)
+
+    def test_square_inequality(self):
+        square1 = Square("e4")
+        square2 = Square("d4")
+        self.assertNotEqual(square1, square2)
+
+    def test_square_hash(self):
+        square1 = Square("e4")
+        square2 = Square("e4")
+        square_set = {square1, square2}
+        self.assertEqual(len(square_set), 1)
+
+    def test_square_from_row_col(self):
+        self.assertEqual(Squares.square_from_row_col(0, 0), Squares.A1)
+        self.assertEqual(Squares.square_from_row_col(7, 7), Squares.H8)
+        self.assertEqual(Squares.square_from_row_col(4, 4), Squares.E5)
+        self.assertEqual(Squares.square_from_row_col(6, 2), Squares.C7)
+        self.assertEqual(Squares.square_from_row_col(2, 6), Squares.G3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The new Square class makes it easier to pass around the squares being referenced, without needing to move back and forth from algo to row and col format.

The move class encloses all the required parts of a move, like the captured piece or promotion type (if any)