### PR TITLE
Enable strict mypy typing for move_test and square_test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
       name: mypy strict
       args: [--strict]
       # TODO: Once this exclude list is handle, we can delete the non-strict mypy step and just run this one.
-      exclude: chess_engine_test.py|move_test.py|square_test.py|chess_engine.py|uci_interface_test.py|self_play.py
+      exclude: chess_engine_test.py|chess_engine.py|uci_interface_test.py|self_play.py

--- a/chess_engine_v1/move_test.py
+++ b/chess_engine_v1/move_test.py
@@ -5,7 +5,7 @@ from square import Squares
 
 
 class TestMove(unittest.TestCase):
-    def test_move_initialization(self):
+    def test_move_initialization(self) -> None:
         move = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(move.start, Squares.E2)
         self.assertEqual(move.end, Squares.E4)
@@ -13,7 +13,7 @@ class TestMove(unittest.TestCase):
         self.assertEqual(move.piece_captured, "p")
         self.assertIsNone(move.promotion_piece)
 
-    def test_move_initialization_with_promotion(self):
+    def test_move_initialization_with_promotion(self) -> None:
         move = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         self.assertEqual(move.start, Squares.E7)
         self.assertEqual(move.end, Squares.E8)
@@ -21,49 +21,49 @@ class TestMove(unittest.TestCase):
         self.assertEqual(move.piece_captured, None)
         self.assertEqual(move.promotion_piece, "Q")
 
-    def test_move_str(self):
+    def test_move_str(self) -> None:
         move = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(str(move), "P from e2 to e4, capturing p")
 
-    def test_move_str_with_promotion(self):
+    def test_move_str_with_promotion(self) -> None:
         move = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         self.assertEqual(str(move), "P from e7 to e8, promoting to Q")
 
-    def test_move_repr(self):
+    def test_move_repr(self) -> None:
         move = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(repr(move), "P from e2 to e4, capturing p")
 
-    def test_move_repr_with_promotion(self):
+    def test_move_repr_with_promotion(self) -> None:
         move = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         self.assertEqual(repr(move), "P from e7 to e8, promoting to Q")
 
-    def test_move_equality(self):
+    def test_move_equality(self) -> None:
         move1 = Move(Squares.E2, Squares.E4, "P", "p")
         move2 = Move(Squares.E2, Squares.E4, "P", "p")
         self.assertEqual(move1, move2)
 
-    def test_move_inequality(self):
+    def test_move_inequality(self) -> None:
         move1 = Move(Squares.E2, Squares.E4, "P", "p")
         move2 = Move(Squares.D2, Squares.D4, "P", "p")
         self.assertNotEqual(move1, move2)
 
-    def test_move_inequality_same_piece_and_squares_other_player(self):
+    def test_move_inequality_same_piece_and_squares_other_player(self) -> None:
         move1 = Move(Squares.E2, Squares.E4, "R")
         move2 = Move(Squares.E2, Squares.E4, "r")
         self.assertNotEqual(move1, move2)
 
-    def test_move_inequality_with_promotion(self):
+    def test_move_inequality_with_promotion(self) -> None:
         move1 = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         move2 = Move(Squares.E7, Squares.E8, "P", promotion_piece="R")
         self.assertNotEqual(move1, move2)
 
-    def test_move_hash(self):
+    def test_move_hash(self) -> None:
         move1 = Move(Squares.E2, Squares.E4, "P", "p")
         move2 = Move(Squares.E2, Squares.E4, "P", "p")
         move_set = {move1, move2}
         self.assertEqual(len(move_set), 1)
 
-    def test_move_hash_with_promotion(self):
+    def test_move_hash_with_promotion(self) -> None:
         move1 = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         move2 = Move(Squares.E7, Squares.E8, "P", promotion_piece="Q")
         move_set = {move1, move2}

--- a/chess_engine_v1/square_test.py
+++ b/chess_engine_v1/square_test.py
@@ -4,13 +4,13 @@ from square import Square, Squares
 
 
 class TestSquare(unittest.TestCase):
-    def test_square_initialization(self):
+    def test_square_initialization(self) -> None:
         square = Square("e4")
         self.assertEqual(square.algebraic, "e4")
         self.assertEqual(square.row, 3)
         self.assertEqual(square.col, 4)
 
-    def test_square_row(self):
+    def test_square_row(self) -> None:
         self.assertEqual(Squares.A1.row, 0)
         self.assertEqual(Squares.B8.row, 7)
         self.assertEqual(Squares.C2.row, 1)
@@ -20,7 +20,7 @@ class TestSquare(unittest.TestCase):
         self.assertEqual(Squares.G4.row, 3)
         self.assertEqual(Squares.H5.row, 4)
 
-    def test_square_col(self):
+    def test_square_col(self) -> None:
         self.assertEqual(Squares.A1.col, 0)
         self.assertEqual(Squares.B8.col, 1)
         self.assertEqual(Squares.C2.col, 2)
@@ -30,31 +30,31 @@ class TestSquare(unittest.TestCase):
         self.assertEqual(Squares.G4.col, 6)
         self.assertEqual(Squares.H5.col, 7)
 
-    def test_square_str(self):
+    def test_square_str(self) -> None:
         square = Square("e4")
         self.assertEqual(str(square), "e4")
 
-    def test_square_repr(self):
+    def test_square_repr(self) -> None:
         square = Square("e4")
         self.assertEqual(repr(square), "e4")
 
-    def test_square_equality(self):
+    def test_square_equality(self) -> None:
         square1 = Square("e4")
         square2 = Square("e4")
         self.assertEqual(square1, square2)
 
-    def test_square_inequality(self):
+    def test_square_inequality(self) -> None:
         square1 = Square("e4")
         square2 = Square("d4")
         self.assertNotEqual(square1, square2)
 
-    def test_square_hash(self):
+    def test_square_hash(self) -> None:
         square1 = Square("e4")
         square2 = Square("e4")
         square_set = {square1, square2}
         self.assertEqual(len(square_set), 1)
 
-    def test_square_from_row_col(self):
+    def test_square_from_row_col(self) -> None:
         self.assertEqual(Squares.square_from_row_col(0, 0), Squares.A1)
         self.assertEqual(Squares.square_from_row_col(7, 7), Squares.H8)
         self.assertEqual(Squares.square_from_row_col(4, 4), Squares.E5)


### PR DESCRIPTION
Fix all related errors, which are just adding simple "-> None" to the tests.